### PR TITLE
#GH-13 fixed bug causing crash when standup section is not present

### DIFF
--- a/webapp/src/components/standupModal/standupModal.jsx
+++ b/webapp/src/components/standupModal/standupModal.jsx
@@ -207,7 +207,7 @@ class StandupModal extends (SentryBoundary, React.Component) {
                             onChange={onChange}
                             name={'line' + (i + 1)}
                             className={className}
-                            value={this.state.standup[className][`line${i + 1}`] || ''}
+                            value={this.state.standup[className] ? (this.state.standup[className][`line${i + 1}`] || '') : ''}
                         />
                         <FormControl.Feedback/>
                     </InputGroup>


### PR DESCRIPTION
### Summary
Fixed bug causing a crash when standup section is not present

### Checklist
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides

This fixes #13 