### PR TITLE
#GH-30 Migrated from XMLHTTPRequest to using CSRF token

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -4696,6 +4696,11 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -35,6 +35,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "copy-webpack-plugin": "^4.6.0",
     "http-status-codes": "^1.3.2",
+    "js-cookie": "^2.2.0",
     "mattermost-redux": "^5.5.1",
     "react": "^16.7.0",
     "react-bootstrap": "^0.32.4",

--- a/webapp/src/components/configModal/configModal.jsx
+++ b/webapp/src/components/configModal/configModal.jsx
@@ -18,6 +18,7 @@ import style from './style.css';
 import reactStyles from './style';
 import SentryBoundary from '../../SentryBoundary';
 import * as HttpStatus from 'http-status-codes';
+import Cookies from "js-cookie";
 
 const configModalCloseTimeout = 1000;
 
@@ -196,7 +197,7 @@ class ConfigModal extends (SentryBoundary, React.Component) {
             .post(Constants.URL_STANDUP_CONFIG)
             .withCredentials()
             .send(this.prepareStandupConfigPayload())
-            .set('X-Requested-With', 'XMLHttpRequest')
+            .set('X-CSRF-Token', Cookies.get(Constants.MATTERMOST_CSRF_COOKIE))
             .set('Content-Type', 'application/json')
             .end((err, res) => {
                 if (err) {

--- a/webapp/src/components/configModal/configModal.jsx
+++ b/webapp/src/components/configModal/configModal.jsx
@@ -18,7 +18,7 @@ import style from './style.css';
 import reactStyles from './style';
 import SentryBoundary from '../../SentryBoundary';
 import * as HttpStatus from 'http-status-codes';
-import Cookies from "js-cookie";
+import Cookies from 'js-cookie';
 
 const configModalCloseTimeout = 1000;
 

--- a/webapp/src/components/standupModal/standupModal.jsx
+++ b/webapp/src/components/standupModal/standupModal.jsx
@@ -6,6 +6,7 @@ import Constants from '../../constants';
 import reactStyles from './style';
 import SentryBoundary from '../../SentryBoundary';
 import * as HttpStatus from 'http-status-codes';
+import Cookies from 'js-cookie';
 
 const standupModalCloseTimeout = 1000;
 const standupTaskDefaultRowCount = 5;
@@ -78,7 +79,7 @@ class StandupModal extends (SentryBoundary, React.Component) {
             .post(Constants.URL_SUBMIT_USER_STANDUP)
             .withCredentials()
             .send(payload)
-            .set('X-Requested-With', 'XMLHttpRequest')
+            .set('X-CSRF-Token', Cookies.get(Constants.MATTERMOST_CSRF_COOKIE))
             .set('Content-Type', 'application/json')
             .end((err, res) => {
                 if (err) {

--- a/webapp/src/constants/index.js
+++ b/webapp/src/constants/index.js
@@ -16,6 +16,8 @@ const URL_PLUGIN_ICON = `${PLUGIN_STATIC_DIR_URL}/logo.png`;
 
 const URL_SPINNER_ICON = `${PLUGIN_STATIC_DIR_URL}/spinner.svg`;
 
+const MATTERMOST_CSRF_COOKIE = 'MMCSRF';
+
 const ACTIONS = {
     OPEN_STANDUP_MODAL: `${PLUGIN_NAME}_open_standup_modal`,
     CLOSE_STANDUP_MODAL: `${PLUGIN_NAME}_close_standup_modal`,
@@ -31,4 +33,5 @@ export default {
     ACTIONS,
     PLUGIN_NAME,
     PLUGIN_DISPLAY_NAME,
+    MATTERMOST_CSRF_COOKIE,
 };


### PR DESCRIPTION
### Summary
Migrated from XMLHTTPRequest to using CSRF token as the former will be depricated by Mattermost.

### Checklist
- [x]  Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
