### PR TITLE
#GH-40 `@` in the standup report for people who have not submitted.

### DIFF
--- a/server/standup/notification/notification.go
+++ b/server/standup/notification/notification.go
@@ -504,7 +504,7 @@ func generateUserAggregatedStandupReport(
 	text := fmt.Sprintf("#### Standup Report for *%s*\n", date.Format("2 Jan 2006"))
 
 	if len(membersNoStandup) > 0 {
-		text += fmt.Sprintf("\n%s %s not submitted their standup\n\n", strings.Join(membersNoStandup, ", "), util.HasHave(len(membersNoStandup)))
+		text += fmt.Sprintf("\n@%s %s not submitted their standup\n\n", strings.Join(membersNoStandup, ", @"), util.HasHave(len(membersNoStandup)))
 	}
 
 	text += userTasks

--- a/server/standup/notification/notification.go
+++ b/server/standup/notification/notification.go
@@ -115,8 +115,7 @@ func SendStandupReport(channelIDs []string, date otime.OTime, visibility string,
 					return errors.New(appErr.Error())
 				}
 
-				userDisplayName := user.GetDisplayName(model.SHOW_FULLNAME)
-				membersNoStandup = append(membersNoStandup, userDisplayName)
+				membersNoStandup = append(membersNoStandup, user.Username)
 
 				continue
 			}


### PR DESCRIPTION
### Summary
`@` is added in along with the usernames/handles in the standup report for people who have not submitted.

### Checklist
- [x] Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
