### PR TITLE
#GH-49 Moved all Sentry configurations to build_properties.json and removed sentry.properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ quickdist: .distclean plugin.json
 
 	# Build files from server
 	 cd server && go get github.com/mitchellh/gox
-	 $(shell go env GOPATH)/bin/gox -ldflags="-X main.SentryEnabled=$(call GetFromPkg,sentryEnabled) -X main.SentryDSN=$(call GetFromPkg,sentryDSN)" -osarch='darwin/amd64 linux/amd64 windows/amd64' -gcflags='all=-N -l' -output 'dist/intermediate/plugin_{{.OS}}_{{.Arch}}' ./server
+	 $(shell go env GOPATH)/bin/gox -ldflags="-X main.SentryEnabled=$(call GetFromPkg,sentry.enabled) -X main.SentryDSN=$(call GetFromPkg,sentry.dsn)" -osarch='darwin/amd64 linux/amd64 windows/amd64' -gcflags='all=-N -l' -output 'dist/intermediate/plugin_{{.OS}}_{{.Arch}}' ./server
 
 	# Copy plugin files
 	cp plugin.json dist/$(PLUGINNAME)/

--- a/build_properties.json
+++ b/build_properties.json
@@ -1,6 +1,6 @@
 {
   "sentry": {
-    "enabled": true,
+    "enabled": false,
     "dsn": "",
     "server_url": "",
     "org": "",

--- a/build_properties.json
+++ b/build_properties.json
@@ -1,4 +1,10 @@
 {
-  "sentryEnabled": false,
-  "sentryDSN": ""
+  "sentry": {
+    "enabled": true,
+    "dsn": "",
+    "server_url": "",
+    "org": "",
+    "project": "",
+    "auth_token": ""
+  }
 }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5753,6 +5753,12 @@
         "warning": "^3.0.0"
       }
     },
+    "properties-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/properties-file/-/properties-file-1.0.0.tgz",
+      "integrity": "sha1-NQgJnFHSbDtcj4IQ6rfo+mpP6WY=",
+      "dev": true
+    },
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-react": "^7.10.0",
     "prop-types": "latest",
+    "properties-file": "^1.0.0",
     "style-loader": "^0.23.1",
     "svg-inline-loader": "^0.8.0",
     "webpack": "^4.27.1",

--- a/webapp/sentry.properties
+++ b/webapp/sentry.properties
@@ -1,4 +1,0 @@
-defaults.url=https://sentry.io
-defaults.org=org
-defaults.project=project
-auth.token=token

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -79,11 +79,11 @@ if (buildProperties.sentry.enabled) {
 
 function generateSentryCLIConfig(sentrySettings) {
     const sentryCLIConfig = {
-        "defaults.url": sentrySettings.server_url,
-        "defaults.org": sentrySettings.org,
-        "defaults.project": sentrySettings.project,
-        "auth.token": sentrySettings.auth_token,
+        'defaults.url': sentrySettings.server_url,
+        'defaults.org': sentrySettings.org,
+        'defaults.project': sentrySettings.project,
+        'auth.token': sentrySettings.auth_token,
     };
-    
+
     fs.writeFileSync('./sentry.properties', propertiesParser.stringify(sentryCLIConfig));
 }

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -2,6 +2,8 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const SentryWebpackPlugin = require('@sentry/webpack-plugin');
 const buildProperties = require('../build_properties.json');
+const fs = require('fs');
+const propertiesParser = require('properties-file');
 
 module.exports = {
     devtool: 'inline-source-map',
@@ -63,7 +65,8 @@ module.exports = {
     },
 };
 
-if (buildProperties.sentryEnabled) {
+if (buildProperties.sentry.enabled) {
+    generateSentryCLIConfig(buildProperties.sentry);
     module.exports.plugins.push(
         new SentryWebpackPlugin({
             include: '.',
@@ -72,4 +75,15 @@ if (buildProperties.sentryEnabled) {
             configFile: 'sentry.properties',
         })
     );
+}
+
+function generateSentryCLIConfig(sentrySettings) {
+    const sentryCLIConfig = {
+        "defaults.url": sentrySettings.server_url,
+        "defaults.org": sentrySettings.org,
+        "defaults.project": sentrySettings.project,
+        "auth.token": sentrySettings.auth_token,
+    };
+    
+    fs.writeFileSync('./sentry.properties', propertiesParser.stringify(sentryCLIConfig));
 }


### PR DESCRIPTION
### Summary
Moved all Sentry configurations to build_properties.json and removed sentry.properties. This will make `build_properties.json` the single source of truth for all build time configuration values.

`webapp/sentry.properties` is now automatically generated, deriving from `build_properties.json`

### Checklist
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
