### PR TITLE
#GH-53 Using public DSN for Sentry in webpp component

### DIFF
--- a/build_properties.json
+++ b/build_properties.json
@@ -2,6 +2,7 @@
   "sentry": {
     "enabled": false,
     "dsn": "",
+    "publicDsn": "",
     "server_url": "",
     "org": "",
     "project": "",

--- a/webapp/src/index.jsx
+++ b/webapp/src/index.jsx
@@ -36,7 +36,7 @@ class StandupRavenPlugin {
 
 function initSentry() {
     Sentry.init({
-        dsn: buildProperties.sentryDSN,
+        dsn: buildProperties.sentry.publicDsn,
     });
 
     Sentry.configureScope(((scope) => {


### PR DESCRIPTION
### Summary
Using public DSN for Sentry in webpp component

### Checklist
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
