### PR TITLE
#GH-89 removed incorrect help text for /standup base command

### DIFF
--- a/server/command/master.go
+++ b/server/command/master.go
@@ -14,7 +14,7 @@ func Master() *Config {
 		Command: &model.Command{
 			Trigger:          config.CommandPrefix,
 			AutoComplete:     true,
-			AutoCompleteDesc: "Available commands: " + strings.Join(getAvailableCommands(), ", ") + " ; <command> --help for individual command help",
+			AutoCompleteDesc: "Available commands: " + strings.Join(getAvailableCommands(), ", "),
 		},
 		HelpText: "",
 		Validate: validateCommandMaster,


### PR DESCRIPTION
### Summary
removed incorrect help text for /standup base command

### Checklist
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
