### PR TITLE
#GH-78 Added ability to include standup schedule in channel header

### DIFF
--- a/server/command/master.go
+++ b/server/command/master.go
@@ -57,7 +57,7 @@ func validateCommandMaster(args []string, context Context) (*model.CommandRespon
 func executeCommandMaster(args []string, context Context) (*model.CommandResponse, *model.AppError) {
 	var response *model.CommandResponse
 	var appErr *model.AppError
-	
+
 	if _, ok := context.Props["subCommand"]; ok {
 		subCommand := context.Props["subCommand"].(*Config)
 		subCommandArgs := context.Props["subCommandArgs"].([]string)
@@ -73,11 +73,11 @@ func executeCommandMaster(args []string, context Context) (*model.CommandRespons
 			},
 		)
 
-		response, appErr =  &model.CommandResponse{
+		response, appErr = &model.CommandResponse{
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 			Text:         "Submit your standup from the open modal!",
 		}, nil
 	}
-	
+
 	return response, appErr
 }

--- a/server/command/master_test.go
+++ b/server/command/master_test.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/standup-raven/standup-raven/server/util"
 	"github.com/stretchr/testify/assert"

--- a/server/glide.lock
+++ b/server/glide.lock
@@ -1,10 +1,12 @@
-hash: 1f98fe7e9c2b5284681d0dfb33cbfbbada69f570ed38910dce69cc5a02f7a32c
-updated: 2019-06-18T23:07:40.131869528+05:30
+hash: 4efcc52ad61d021a5ec848f94be74e20c0b07522bbf39023ca31c5a801f3a0d8
+updated: 2019-11-30T09:00:29.814831+05:30
 imports:
+- name: bou.ke/monkey
+  version: bdf6dea004c6fd1cdf4b25da8ad45a606c09409a
 - name: github.com/blang/semver
   version: 3c1074078d32d767e08ab2c8564867292da86926
-- name: github.com/bouk/monkey
-  version: bdf6dea004c6fd1cdf4b25da8ad45a606c09409a
+- name: github.com/BurntSushi/toml
+  version: 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
 - name: github.com/certifi/gocertifi
   version: deb3ae2ef2610fde3330947281941c562861188b
 - name: github.com/davecgh/go-spew
@@ -45,7 +47,7 @@ imports:
   - i18n/language
   - i18n/translation
 - name: github.com/mattermost/mattermost-server
-  version: bfd66aa445a2df8c6ed6ba9f2567021ecf6c9f3b
+  version: 96e36f73b25d7caa4d09c4a967fea54f57e9a52c
   subpackages:
   - mlog
   - model
@@ -74,17 +76,21 @@ imports:
 - name: github.com/stretchr/objx
   version: ea4fe68685ee0d3cee7032121851b57e7494e8ea
 - name: github.com/stretchr/testify
-  version: ffdc059bfe9ce6a4e144ba849dbedead332c6053
+  version: 221dbe5ed46703ee255b1da0dec05086f5035f62
   subpackages:
   - assert
   - mock
   - require
 - name: github.com/thoas/go-funk
-  version: c43409e2d5def27be9b081e316441108def35c8d
+  version: 310880620b0fe943c45bf032685df5fdf5f4c14e
 - name: go.uber.org/atomic
-  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
+  version: 40ae6a40a970ef4cdbffa7b24b280e316db8accc
 - name: go.uber.org/multierr
-  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
+  version: 824d08f79702fe5f54aca8400aa0d754318786e7
+- name: go.uber.org/tools
+  version: 2cfd321de3ee5d5f8a5fda2521d1703478334d98
+  subpackages:
+  - update-license
 - name: go.uber.org/zap
   version: 2dc8d10634f473f4dc678e48391a9dc8cf6ae6f9
   subpackages:
@@ -98,6 +104,10 @@ imports:
   subpackages:
   - bcrypt
   - blowfish
+- name: golang.org/x/lint
+  version: fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448
+  subpackages:
+  - golint
 - name: golang.org/x/net
   version: aaf60122140d3fcf75376d319f0554393160eb50
   subpackages:
@@ -125,6 +135,26 @@ imports:
   - transform
   - unicode/bidi
   - unicode/norm
+- name: golang.org/x/tools
+  version: ecd32218bd7f33fd31c1abbfb74283690bedd093
+  subpackages:
+  - go/analysis
+  - go/analysis/passes/inspect
+  - go/ast/astutil
+  - go/ast/inspector
+  - go/buildutil
+  - go/gcexportdata
+  - go/internal/cgo
+  - go/internal/gcimporter
+  - go/internal/packagesdriver
+  - go/loader
+  - go/packages
+  - go/types/objectpath
+  - go/types/typeutil
+  - internal/fastwalk
+  - internal/gopathwalk
+  - internal/semver
+  - internal/span
 - name: google.golang.org/genproto
   version: c66870c02cf823ceb633bcd05be3c7cda29976f4
   subpackages:
@@ -165,4 +195,38 @@ imports:
   version: a96e63847dc3c67d17befa69c303767e2f84e54f
 - name: gopkg.in/yaml.v2
   version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
-testImports: []
+- name: honnef.co/go/tools
+  version: dfe37feaecf7b73ce53f4fb8fa347265a77c6c4b
+  subpackages:
+  - arg
+  - cmd/staticcheck
+  - code
+  - config
+  - deprecated
+  - edit
+  - facts
+  - functions
+  - go/types/typeutil
+  - internal/cache
+  - internal/passes/buildir
+  - internal/renameio
+  - internal/robustio
+  - internal/sharedcheck
+  - ir
+  - ir/irutil
+  - lint
+  - lint/lintdsl
+  - lint/lintutil
+  - lint/lintutil/format
+  - loader
+  - pattern
+  - printf
+  - report
+  - simple
+  - staticcheck
+  - stylecheck
+  - unused
+  - version
+testImports:
+- name: bou.ke/monkey
+  version: bdf6dea004c6fd1cdf4b25da8ad45a606c09409a

--- a/server/glide.yaml
+++ b/server/glide.yaml
@@ -14,5 +14,5 @@ import:
   version: ^1.3.0
   subpackages:
   - assert
-- package: github.com/bouk/monkey
+- package: bou.ke/monkey
   version: ^1.0.1

--- a/server/migration/main_test.go
+++ b/server/migration/main_test.go
@@ -3,7 +3,7 @@ package migration
 import (
 	"encoding/json"
 	"errors"
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/standup-raven/standup-raven/server/config"

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/standup-raven/standup-raven/server/config"

--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -122,7 +122,7 @@ func (sc *StandupConfig) ToJson() string {
 	return string(b)
 }
 
-// Generates a user-friendly, string representation of standup schedule.
+// GenerateScheduleString generates a user-friendly, string representation of standup schedule.
 func (sc *StandupConfig) GenerateScheduleString() string {
 	pluginConfig := config.GetConfig()
 

--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -60,6 +60,8 @@ type StandupConfig struct {
 	Timezone                   string      `json:"timezone"`
 	WindowOpenReminderEnabled  bool        `json:"windowOpenReminderEnabled"`
 	WindowCloseReminderEnabled bool        `json:"windowCloseReminderEnabled"`
+	ScheduleEnabled            bool        `json:"scheduleEnabled"`
+	Schedule                   string      `json:"schedule"`
 }
 
 func (sc *StandupConfig) IsValid() error {
@@ -217,6 +219,8 @@ func SaveStandupConfig(standupConfig *StandupConfig) (*StandupConfig, error) {
 		return nil, err
 	}
 
+	updateChannelHeader(standupConfig)
+
 	key := config.CacheKeyPrefixTeamStandupConfig + standupConfig.ChannelId
 	if err := config.Mattermost.KVSet(util.GetKeyHash(key), serializedStandupConfig); err != nil {
 		logger.Error("Couldn't save channel standup config in KV store", err, map[string]interface{}{"channelID": standupConfig.ChannelId})
@@ -224,6 +228,49 @@ func SaveStandupConfig(standupConfig *StandupConfig) (*StandupConfig, error) {
 	}
 
 	return standupConfig, nil
+}
+
+func updateChannelHeader(newConfig *StandupConfig) {
+	channelID := newConfig.ChannelId
+
+	oldConfig, err := GetStandupConfig(channelID)
+	if err != nil {
+		logger.Error("Error getting channel", err, nil)
+		return
+	}
+
+	if !oldConfig.ScheduleEnabled && !newConfig.ScheduleEnabled {
+		return
+	}
+
+	channel, err := config.Mattermost.GetChannel(channelID)
+	if err != nil {
+		logger.Error("Error getting Channel", err, nil)
+		return
+	}
+
+	if oldConfig.ScheduleEnabled && newConfig.ScheduleEnabled {
+		if oldConfig.WindowOpenTime != newConfig.WindowOpenTime || oldConfig.WindowCloseTime != newConfig.WindowCloseTime || oldConfig.Timezone != newConfig.Timezone {
+			x := strings.SplitAfterN(channel.Header, "|", 2)[1:]
+			updatedHeader := newConfig.Schedule + " | " + strings.TrimSpace(strings.Join(x, ""))
+
+			channel.Header = updatedHeader
+		}
+	} else if newConfig.ScheduleEnabled {
+		if len(channel.Header) > 0 {
+			updatedHeader := newConfig.Schedule + " | " + channel.Header
+			channel.Header = updatedHeader
+		} else {
+			updatedHeader := newConfig.Schedule
+			channel.Header = updatedHeader
+		}
+	} else {
+		x := strings.SplitAfterN(channel.Header, "|", 2)[1:]
+		updatedHeader := strings.TrimSpace(strings.Join(x, ""))
+		channel.Header = updatedHeader
+	}
+
+	config.Mattermost.UpdateChannel(channel)
 }
 
 // GetStandupConfig fetches standup config for the specified channel

--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -2,11 +2,11 @@ package standup
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/standup-raven/standup-raven/server/config"
 	"github.com/standup-raven/standup-raven/server/logger"
 	"github.com/standup-raven/standup-raven/server/otime"

--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	standupSectionsMinLength = 1
+	standupSectionsMinLength       = 1
 	channelHeaderScheduleSeparator = "|"
 )
 
@@ -124,15 +124,15 @@ func (sc *StandupConfig) ToJson() string {
 
 func (sc *StandupConfig) GenerateScheduleString() string {
 	pluginConfig := config.GetConfig()
-	
+
 	windowOpenTime := sc.WindowOpenTime.Format("15:04")
 	windowCloseTime := sc.WindowCloseTime.Format("15:04")
-	
-	workWeekStartNumber, _ := strconv.Atoi(pluginConfig.WorkWeekStart) 
-	workWeekEndNumber, _ := strconv.Atoi(pluginConfig.WorkWeekEnd) 
+
+	workWeekStartNumber, _ := strconv.Atoi(pluginConfig.WorkWeekStart)
+	workWeekEndNumber, _ := strconv.Atoi(pluginConfig.WorkWeekEnd)
 	workWeekStart := time.Weekday(workWeekStartNumber).String()
 	workWeekEnd := time.Weekday(workWeekEndNumber).String()
-	
+
 	return fmt.Sprintf("**Standup Schedule**: %s to %s, %s to %s", workWeekStart, workWeekEnd, windowOpenTime, windowCloseTime)
 }
 
@@ -255,7 +255,7 @@ func updateChannelHeader(newConfig *StandupConfig) error {
 	if appErr != nil {
 		return errors.New(appErr.Error())
 	}
-	
+
 	if oldConfig.ScheduleEnabled && !newConfig.ScheduleEnabled {
 		channel.Header = removeChannelHeaderSchedule(channel.Header)
 	} else if !oldConfig.ScheduleEnabled && newConfig.ScheduleEnabled {
@@ -264,12 +264,12 @@ func updateChannelHeader(newConfig *StandupConfig) error {
 		channel.Header = removeChannelHeaderSchedule(channel.Header)
 		channel.Header = addChannelHeaderSchedule(channel.Header, newConfig.GenerateScheduleString())
 	}
-	
+
 	_, appErr = config.Mattermost.UpdateChannel(channel)
 	if appErr != nil {
 		return errors.New(appErr.Error())
 	}
-	
+
 	return nil
 }
 
@@ -278,12 +278,12 @@ func removeChannelHeaderSchedule(channelHeader string) string {
 	if len(components) < 2 {
 		return channelHeader
 	}
-	
+
 	updatedHeader := strings.TrimLeft(components[1], " ")
 	if len(components) > 2 {
 		updatedHeader = updatedHeader + "|" + strings.Join(components[2:], "|")
 	}
-	
+
 	return updatedHeader
 }
 

--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -122,6 +122,7 @@ func (sc *StandupConfig) ToJson() string {
 	return string(b)
 }
 
+// Generates a user-friendly, string representation of standup schedule.
 func (sc *StandupConfig) GenerateScheduleString() string {
 	pluginConfig := config.GetConfig()
 

--- a/server/standup/main_test.go
+++ b/server/standup/main_test.go
@@ -2,7 +2,7 @@ package standup
 
 import (
 	"encoding/json"
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest/mock"
 	"github.com/pkg/errors"
@@ -393,7 +393,10 @@ func TestGetUserStandup(t *testing.T) {
 func TestSaveStandupConfig(t *testing.T) {
 	defer TearDown()
 	mockAPI := baseMock()
+	mockAPI.On("KVGet", util.GetKeyHash("standup_config_channel_id")).Return([]byte("{\"scheduleEnabled\":false}"), nil)
 	mockAPI.On("KVSet", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	mockAPI.On("GetChannel", "channel_id").Return(&model.Channel{}, nil)
+	mockAPI.On("UpdateChannel", mock.Anything).Return(nil, nil)
 
 	standupConfig := &StandupConfig{
 		ChannelId: "channel_id",
@@ -403,6 +406,7 @@ func TestSaveStandupConfig(t *testing.T) {
 		 Sections: []string{"section 1"},
 		 ReportFormat: config.ReportFormatUserAggregated,
 		 Enabled: true,
+		 ScheduleEnabled: true,
 	}
 
 	savedStandupConfig, err := SaveStandupConfig(standupConfig)
@@ -410,6 +414,9 @@ func TestSaveStandupConfig(t *testing.T) {
 	assert.Equal(t, standupConfig, savedStandupConfig, "both standup config should be identical")
 
 	mockAPI = baseMock()
+	mockAPI.On("KVGet", util.GetKeyHash("standup_config_channel_id")).Return([]byte("{\"scheduleEnabled\":false}"), nil)
+	mockAPI.On("GetChannel", "channel_id").Return(&model.Channel{}, nil)
+	mockAPI.On("UpdateChannel", mock.Anything).Return(nil, nil)
 	mockAPI.On("KVSet", mock.AnythingOfType("string"), mock.Anything).Return(util.EmptyAppError())
 
 	savedStandupConfig, err = SaveStandupConfig(standupConfig)
@@ -422,6 +429,9 @@ func TestSaveStandupConfig(t *testing.T) {
 func TestSaveStandupConfig_DuplicateMembers(t *testing.T) {
 	defer TearDown()
 	mockAPI := baseMock()
+	mockAPI.On("KVGet", util.GetKeyHash("standup_config_channel_id")).Return([]byte("{\"scheduleEnabled\":false}"), nil)
+	mockAPI.On("GetChannel", "channel_id").Return(&model.Channel{}, nil)
+	mockAPI.On("UpdateChannel", mock.Anything).Return(nil, nil)
 	mockAPI.On("KVSet", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	
 	now := otime.Now("Asia/Kolkata")

--- a/server/standup/notification/notification_test.go
+++ b/server/standup/notification/notification_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/mattermost/mattermost-server/plugin/plugintest/mock"

--- a/server/util/util_test.go
+++ b/server/util/util_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/standup-raven/standup-raven/server/otime"
 	"net/http"

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5773,9 +5773,9 @@
       },
       "dependencies": {
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
         }
       }
     },

--- a/webapp/src/components/configModal/configModal.jsx
+++ b/webapp/src/components/configModal/configModal.jsx
@@ -240,7 +240,6 @@ class ConfigModal extends (SentryBoundary, React.Component) {
     };
 
     prepareStandupConfigPayload() {
-        const {windowOpenTime, windowCloseTime, timezone} = this.state;
         return {
             channelId: this.props.channelID,
             windowOpenTime: this.state.windowOpenTime,
@@ -253,7 +252,6 @@ class ConfigModal extends (SentryBoundary, React.Component) {
             windowCloseReminderEnabled: this.state.windowCloseReminderEnabled,
             windowOpenReminderEnabled: this.state.windowOpenReminderEnabled,
             scheduleEnabled: this.state.scheduleEnabled,
-            schedule: (this.state.scheduleEnabled ? `Mon-Fri from ${windowOpenTime} to ${windowCloseTime} ${timezone}` : ''),
         };
     }
 

--- a/webapp/src/components/configModal/configModal.jsx
+++ b/webapp/src/components/configModal/configModal.jsx
@@ -75,6 +75,8 @@ class ConfigModal extends (SentryBoundary, React.Component) {
             windowOpenReminderEnabled: true,
             windowCloseReminderEnabled: true,
             timezone: '',
+            scheduleEnabled: false,
+            schedule: '',
         };
     };
 
@@ -120,6 +122,12 @@ class ConfigModal extends (SentryBoundary, React.Component) {
     handleWindowOpenReminderChange = () => {
         this.setState({
             windowOpenReminderEnabled: !this.state.windowOpenReminderEnabled,
+        });
+    };
+
+    handleScheduleStatusChange = () => {
+        this.setState({
+            scheduleEnabled: !this.state.scheduleEnabled,
         });
     };
 
@@ -192,6 +200,8 @@ class ConfigModal extends (SentryBoundary, React.Component) {
                             timezone: standupConfig.timezone,
                             windowOpenReminderEnabled: standupConfig.windowOpenReminderEnabled,
                             windowCloseReminderEnabled: standupConfig.windowCloseReminderEnabled,
+                            scheduleEnabled: standupConfig.scheduleEnabled,
+                            schedule: standupConfig.schedule,
                         };
 
                         for (let i = 0; i < standupConfig.sections.length; ++i) {
@@ -230,6 +240,7 @@ class ConfigModal extends (SentryBoundary, React.Component) {
     };
 
     prepareStandupConfigPayload() {
+        const {windowOpenTime, windowCloseTime, timezone} = this.state;
         return {
             channelId: this.props.channelID,
             windowOpenTime: this.state.windowOpenTime,
@@ -241,6 +252,8 @@ class ConfigModal extends (SentryBoundary, React.Component) {
             timezone: this.state.timezone,
             windowCloseReminderEnabled: this.state.windowCloseReminderEnabled,
             windowOpenReminderEnabled: this.state.windowOpenReminderEnabled,
+            scheduleEnabled: this.state.scheduleEnabled,
+            schedule: (this.state.scheduleEnabled ? `Mon-Fri from ${windowOpenTime} to ${windowCloseTime} ${timezone}` : ''),
         };
     }
 
@@ -414,6 +427,16 @@ class ConfigModal extends (SentryBoundary, React.Component) {
                             <ToggleSwitch
                                 onChange={this.handleWindowCloseReminderChange}
                                 checked={this.state.windowCloseReminderEnabled}
+                                theme={this.props.theme}
+                            />
+                        </FormGroup>
+                        <FormGroup style={style.formGroup}>
+                            <ControlLabel style={style.controlLabel}>
+                                {'Standup Schedule:'}
+                            </ControlLabel>
+                            <ToggleSwitch
+                                onChange={this.handleScheduleStatusChange}
+                                checked={this.state.scheduleEnabled}
                                 theme={this.props.theme}
                             />
                         </FormGroup>


### PR DESCRIPTION
### Summary
Added ability to include standup schedule in channel header

### Checklist
- [x] Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
