### PR TITLE
#GH-126 Fixed a bug causing error in saving standup config for new channels

### DIFF
--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -253,7 +253,7 @@ func updateChannelHeader(newConfig *StandupConfig) error {
 	if err != nil {
 		return err
 	}
-	
+
 	// no old config is equivalent to having standup schedule disabled in old config
 	if oldConfig == nil {
 		oldConfig = &StandupConfig{


### PR DESCRIPTION
This fixed #126 

### Summary
Fixed a bug causing error in saving standup config for new channels

### Checklist
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
