### PR TITLE
#GH-168 fixed Raven icon size issue in non-Chrome browsers

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5773,9 +5773,9 @@
       },
       "dependencies": {
         "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/webapp/src/components/channelHeaderButton/style.css
+++ b/webapp/src/components/channelHeaderButton/style.css
@@ -1,4 +1,4 @@
-.raven-icon {
-  height: 100%;
-  width: 100%;
+.raven-icon, .raven-icon svg {
+  height: 32px;
+  width: 32px;
 }

--- a/webapp/src/components/channelHeaderButton/style.css
+++ b/webapp/src/components/channelHeaderButton/style.css
@@ -1,4 +1,5 @@
-.raven-icon, .raven-icon svg {
+.raven-icon,
+.raven-icon svg {
   height: 32px;
   width: 32px;
 }


### PR DESCRIPTION
### Summary
fixed Raven icon size issue in non-Chrome browsers

### Checklist
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
