### PR TITLE
GH-181 New installation compatibility checks for Mattermost 5.25

### DIFF
--- a/server/migration/3_0_0.go
+++ b/server/migration/3_0_0.go
@@ -69,14 +69,14 @@ func generateRRuleStringByWorkWeek() (string, error) {
 
 	workWeekStart, err := strconv.Atoi(oldConf.WorkWeekStart)
 	if err != nil {
-		logger.Error("Couldn't parse integer in old config work week start", err, nil)
-		return "", err
+		logger.Error("Couldn't parse integer in old config work week start, defaulting to using 1 (Monday)", err, nil)
+		workWeekStart = 1
 	}
 
 	workWeekEnd, err := strconv.Atoi(oldConf.WorkWeekEnd)
 	if err != nil {
-		logger.Error("Couldn't parse integer in old config work week end", err, nil)
-		return "", err
+		logger.Error("Couldn't parse integer in old config work week end, defaulting to using 5 (Friday)", err, nil)
+		workWeekEnd = 5
 	}
 
 	weekdays := getStandupWeekDays(workWeekStart, workWeekEnd)

--- a/server/migration/main.go
+++ b/server/migration/main.go
@@ -81,13 +81,16 @@ func getCurrentSchemaVersion() (string, error) {
 		logger.Error("Couldn't fetch database schema version from KV store", err, nil)
 		return "", err
 	}
-	var version string
-	appErr := json.Unmarshal(key, &version)
-	if appErr != nil {
-		logger.Error("Couldn't marshal database schema version", appErr, nil)
-		return "", appErr
+	if key != nil {
+		var version string
+		appErr := json.Unmarshal(key, &version)
+		if appErr != nil {
+			logger.Error("Couldn't marshal database schema version", appErr, nil)
+			return "", appErr
+		}
+		return version, nil
 	}
-	return version, nil
+	return versionNone, nil
 }
 
 func updateSchemaVersion(version string) error {


### PR DESCRIPTION
### Summary
Add checks to handle old config and schema and enable new installation on Mattermost v5.25
- Added check to handle no old schema version in case of fresh installation and bypass the JSON marshaling.
- Added default values to workWeekStart and workWeekEnd in case an old configuration is not present instead of throwing an error.

### Checklist
- [ ] Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides


PS: Apologies for noob code, not a native Go dev and also first ever OSS contribution. Help me learn and grow please.
