### PR TITLE
#GH-187 Skipped updating channel headers for archived channels

### DIFF
--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -416,6 +416,12 @@ func updateChannelHeader(newConfig *StandupConfig) error {
 	if appErr != nil {
 		return errors.New(appErr.Error())
 	}
+	
+	// Updating an archived channel causes error.
+	// Skip if channel is archived.
+	if channel.DeleteAt != 0 {
+		return nil
+	}
 
 	if oldConfig.ScheduleEnabled && !newConfig.ScheduleEnabled {
 		channel.Header = removeChannelHeaderSchedule(channel.Header)

--- a/server/standup/main.go
+++ b/server/standup/main.go
@@ -416,7 +416,7 @@ func updateChannelHeader(newConfig *StandupConfig) error {
 	if appErr != nil {
 		return errors.New(appErr.Error())
 	}
-	
+
 	// Updating an archived channel causes error.
 	// Skip if channel is archived.
 	if channel.DeleteAt != 0 {

--- a/server/standup/main_test.go
+++ b/server/standup/main_test.go
@@ -1222,3 +1222,23 @@ func TestUpdateChannelHeader_ExistingPipeInHeader(t *testing.T) {
 	assert.Nil(t, err, "no error should have been produced")
 	mockAPI.AssertNumberOfCalls(t, "UpdateChannel", 4)
 }
+
+func TestUpdateChannelHeader_ArchivedChannel(t *testing.T) {
+	defer TearDown()
+	mockAPI := baseMock()
+
+	mockAPI.On("GetChannel", "channel_id_1").Return(&model.Channel{
+		DeleteAt: time.Now().Unix(),
+	}, nil)
+
+	monkey.Patch(GetStandupConfig, func(channelID string) (*StandupConfig, error) {
+		return nil, nil
+	})
+
+	err := updateChannelHeader(&StandupConfig{
+		ChannelId:       "channel_id_1",
+	})
+	
+	assert.Nil(t, err)
+	mockAPI.AssertNumberOfCalls(t, "UpdateChannel", 0)
+}


### PR DESCRIPTION
### Summary
Skipped updating channel headers for archived channels. This fixed v2 to v3 upgrade.

### Checklist
- [x] Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
