### PR TITLE
#GH-241 Fixed bug where Raven channel header icon doesn't show up in Mattermost desktop app

### DIFF
--- a/webapp/src/components/channelHeaderButton/style.css
+++ b/webapp/src/components/channelHeaderButton/style.css
@@ -1,5 +1,3 @@
-.raven-icon,
-.raven-icon svg {
-  height: 100%;
-  width: auto;
+.raven-icon {
+  width: 100%;
 }


### PR DESCRIPTION
Fixed bug where Raven channel header icon doesn't show up in Mattermost desktop app

### Summary
1. Added width property of channel header button icon wrapper.

### Checklist
- [x] Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
