### PR TITLE
#GH-251 Fixed regression bug where raven icons appear too large

### DIFF
--- a/webapp/src/components/channelHeaderButton/button.jsx
+++ b/webapp/src/components/channelHeaderButton/button.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import logo from '../../assets/images/logo.svg';
-import './style.css';
 import PropTypes from 'prop-types';
 import RavenClient from '../../raven-client';
 
@@ -86,7 +85,10 @@ class ChannelHeaderButtonIcon extends React.Component {
         return (
             <span
                 ref={this.handleRef}
-                className={'raven-icon'}
+                style={{
+                    width: '1.8em',
+                    height: '1.8em',
+                }}
                 dangerouslySetInnerHTML={{
                     __html: logo,
                 }}

--- a/webapp/src/components/channelHeaderButton/style.css
+++ b/webapp/src/components/channelHeaderButton/style.css
@@ -1,3 +1,0 @@
-.raven-icon {
-  width: 100%;
-}


### PR DESCRIPTION
### Summary
Fixed regression bug where raven icons appear too large

### Checklist
- [x] Added or updated test cases
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server components comply the style guides
