### PR TITLE
Use webapp's exported version of ReactDOM

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
     ],
     externals: {
         react: 'React',
+        'react-dom': 'ReactDOM',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
### Summary

This PR makes it so the webapp portion of this plugin uses the same version/instance of ReactDOM as the webapp itself. Some more context here https://github.com/mattermost/mattermost-plugin-starter-template/pull/169

Related issue https://github.com/standup-raven/standup-raven/issues/295