### PR TITLE
Bump plugin version to 3.3.0

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,1 @@
+version = 1

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,1 +1,10 @@
 version = 1
+
+test_patterns = ["*_test.go"]
+
+[[analyzers]]
+name = "go"
+enabled = false
+
+[analyzers.meta]
+import_paths = ["github.com/standup-raven/standup-raven/server"]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,7 +4,7 @@ test_patterns = ["*_test.go"]
 
 [[analyzers]]
 name = "go"
-enabled = false
+enabled = true
 
 [analyzers.meta]
 import_paths = ["github.com/standup-raven/standup-raven/server"]

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "standup-raven",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "name": "Standup Raven",
   "description": "A Mattermost plugin for communicating daily standups across teams",
   "homepage_url": "https://standupraven.com/",


### PR DESCRIPTION
### Release notes


Supported Mattermost Server Versions: 6.3.10+
# Added support for running on the Mattermost version 7.8.2

## Enhancements

Replaced CircleCI workflow with GitHub Actions.
Upgraded the golagci-lint version to v1.52.2
Upgraded the Go version to v1.18

## Fixes

[b6f7a21] Bump terser from 4.8.0 to 4.8.1 in /webapp
[3597564] Bump color-string from 1.5.4 to 1.9.1 in /webapp
[c963de0] Bump postcss from 7.0.35 to 7.0.39 in /webapp
[926713c] Bump lodash-es from 4.17.15 to 4.17.21 in /webapp
[fe55eff] Bump github.com/mattermost/mattermost-server/v5 from 5.27.0 to 5.39.0
[a0b6a7b] Bump tar from 6.0.5 to 6.1.11 in /webapp
[a6b85a0] Bump path-parse from 1.0.6 to 1.0.7 in /webapp
[7556cb4] Bump trim-newlines from 3.0.0 to 3.0.1 in /webapp
[35d7098] Bump hosted-git-info from 2.8.8 to 2.8.9 in /webapp
[0f86883] Bump lodash from 4.17.20 to 4.17.21 in /webapp
[be8454f] Bump ssri from 6.0.1 to 6.0.2 in /webapp
[b9e6715] Bump y18n from 4.0.0 to 4.0.1 in /webapp
[db8a08e] Bump elliptic from 6.5.3 to 6.5.4 in /webapp
[6de461e] Bump ini from 1.3.5 to 1.3.8 in /webapp
[e576b57]Bump decode-uri-component from 0.2.0 to 0.2.2 in /webapp
[5bdc7d3]Bump minimist from 1.2.5 to 1.2.8 in /webapp
[431a2e3] Bump qs from 6.9.4 to 6.11.0 in /webapp
[2ca7a5f] Upgrade @sentry/browser from 5.15.5 to 5.27.3
[4c53787] Upgrade mattermost-redux from 5.22.0 to 5.28.1
[e75e544] Upgrade react-datepicker from 2.14.1 to 2.16.0
[9332419] Upgrade react-redux from 5.0.7 to 5.1.2
[cb26b86] Security upgrade mattermost-redux from 5.22.0 to 5.31.2
[5341043] Security upgrade mattermost-redux from 5.22.0 to 5.31.2
[6881563] Bump golang.org/x/net from 0.0.0-20200625001655-4c5254603344 to 0.7.0
[30d0f66] Bump golang.org/x/crypto from 0.0.0-20200622213623-75b288015ac9 to 0.1.0 
[862832c] Bump golang.org/x/text from 0.3.3 to 0.3.8
[901920c] Fixed issue #214 by fixing the close button background color in the standup configuration dialogue. https://github.com/standup-raven/standup-raven/pull/308 
[8430767] Fixed issue #295 by upgrading React version to v17.0.2 and the ReactDom version to v17.0.2  https://github.com/standup-raven/standup-raven/pull/307 
[b52dd69] Fixed issue #301 by adding ReactDom as an external dependency for webapp. https://github.com/standup-raven/standup-raven/pull/306 
